### PR TITLE
Extract underware shared

### DIFF
--- a/Underware/Underware_C_Channel.scad
+++ b/Underware/Underware_C_Channel.scad
@@ -4,7 +4,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -17,6 +17,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -33,7 +34,7 @@ Curve_Radius_in_Units = 2;
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -53,15 +54,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -111,28 +107,36 @@ color_this(Global_Color)
 module curvedChannelBase(radiusMM, widthMM, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[Grid_Size + channelWidth + (radiusMM - channelWidth/2), Grid_Size + channelWidth + (radiusMM - channelWidth/2), baseHeight]){ //Curve_Radius_in_Units*channelWidth/2
         let(adjustedWidth = Grid_Size + channelWidth + (radiusMM - channelWidth/2))
-        fwd((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2 - channelWidth/2) 
-        left((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2) 
+        fwd((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2 - channelWidth/2)
+        left((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2)
         down(baseHeight/2)
             diff("holes"){
                 path_sweep(baseProfile(widthMM = widthMM), turtle(["move", Grid_Size, "arcleft", radiusMM, 90, "move", Grid_Size])) {
-                    tag("holes") ycopies(spacing = Grid_Size, n = Channel_Width_in_Units) right(Grid_Size/2) down(0.01) 
-                        if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
+                    tag("holes") ycopies(spacing = Grid_Size, n = Channel_Width_in_Units) right(Grid_Size/2) down(0.01)
+                        if(Mounting_Method == "Direct Multiboard Screw")
+                          up(Base_Screw_Hole_Inner_Depth)
+                          cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP)
+                          attach(TOP, BOT, overlap=0.01)
+                          cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
                             //wood screw head
                             attach(TOP, BOT, overlap=0.01) cyl(h=Wood_Screw_Head_Height+0.05, d1=Wood_Screw_Thread_Diameter, d2=Wood_Screw_Head_Diameter, $fn=25);
                         else if(Mounting_Method == "Flat") ; //do nothing
                         else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
-                    tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) right(Grid_Size + channelWidth/2 + (radiusMM - channelWidth/2)) back(channelWidth/2 + Grid_Size/2 + (radiusMM - channelWidth/2)) down(0.01) 
-                        if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
+                    tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) right(Grid_Size + channelWidth/2 + (radiusMM - channelWidth/2)) back(channelWidth/2 + Grid_Size/2 + (radiusMM - channelWidth/2)) down(0.01)
+                        if(Mounting_Method == "Direct Multiboard Screw")
+                          up(Base_Screw_Hole_Inner_Depth)
+                          cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP)
+                          attach(TOP, BOT, overlap=0.01)
+                          cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
                             //wood screw head
                             attach(TOP, BOT, overlap=0.01) cyl(h=Wood_Screw_Head_Height+0.05, d1=Wood_Screw_Thread_Diameter, d2=Wood_Screw_Head_Diameter, $fn=25);
                         else if(Mounting_Method == "Flat") ; //do nothing
                         else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
-                    //#tag("holes") right(12.5) back(12.5*Channel_Width_in_Units-12.5)#grid_copies(spacing=Grid_Size, inside=rect([200,200]))cyl(h=8, d=7, $fn=25);//temporary 
+                    //#tag("holes") right(12.5) back(12.5*Channel_Width_in_Units-12.5)#grid_copies(spacing=Grid_Size, inside=rect([200,200]))cyl(h=8, d=7, $fn=25);//temporary
                 }
             }
         children();
@@ -141,116 +145,10 @@ module curvedChannelBase(radiusMM, widthMM, anchor, spin, orient){
 
 module curvedChannelTop(radiusMM, widthMM, heightMM = 12, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[Grid_Size + channelWidth + (radiusMM - channelWidth/2), Grid_Size + channelWidth + (radiusMM - channelWidth/2), topHeight + (heightMM-12)]){
-        fwd((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2 - channelWidth/2) 
-        left((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2)  
+        fwd((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2 - channelWidth/2)
+        left((Grid_Size + channelWidth + (radiusMM - channelWidth/2))/2)
         down(topHeight/2 + (heightMM - 12)/2)
-        path_sweep(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["move", Grid_Size, "arcleft", radiusMM, 90, "move", Grid_Size])); 
+        path_sweep(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["move", Grid_Size, "arcleft", radiusMM, 90, "move", Grid_Size]));
         children();
     }
 }
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_C_Channel.scad
+++ b/Underware/Underware_C_Channel.scad
@@ -113,11 +113,7 @@ module curvedChannelBase(radiusMM, widthMM, anchor, spin, orient){
             diff("holes"){
                 path_sweep(baseProfile(widthMM = widthMM), turtle(["move", Grid_Size, "arcleft", radiusMM, 90, "move", Grid_Size])) {
                     tag("holes") ycopies(spacing = Grid_Size, n = Channel_Width_in_Units) right(Grid_Size/2) down(0.01)
-                        if(Mounting_Method == "Direct Multiboard Screw")
-                          up(Base_Screw_Hole_Inner_Depth)
-                          cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP)
-                          attach(TOP, BOT, overlap=0.01)
-                          cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
+                        if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
                             //wood screw head
@@ -125,11 +121,7 @@ module curvedChannelBase(radiusMM, widthMM, anchor, spin, orient){
                         else if(Mounting_Method == "Flat") ; //do nothing
                         else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
                     tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) right(Grid_Size + channelWidth/2 + (radiusMM - channelWidth/2)) back(channelWidth/2 + Grid_Size/2 + (radiusMM - channelWidth/2)) down(0.01)
-                        if(Mounting_Method == "Direct Multiboard Screw")
-                          up(Base_Screw_Hole_Inner_Depth)
-                          cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP)
-                          attach(TOP, BOT, overlap=0.01)
-                          cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
+                        if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
                             //wood screw head

--- a/Underware/Underware_Connectors.scad
+++ b/Underware/Underware_Connectors.scad
@@ -2,13 +2,13 @@
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @dmgerman on MakerWorld and @David D on Printables for the bolt thread specs
     Jonathan at Keep Making for Multiboard
     @Lyric on Printables for the flush connector idea
 
-    
+
 All parts except for Snap Connector are Licensed Creative Commons 4.0 Attribution Non-Commercial Share-Alike (CC-BY-NC-SA)
 Snap Connector adopts the Multiboard.io license at multiboard.io/license
 */
@@ -16,21 +16,22 @@ Snap Connector adopts the Multiboard.io license at multiboard.io/license
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Show_Part = "Snap Connector"; // [Snap Connector, Bolts]
 
 /*[Options: Thread Snap Connector ]*/
-//Height (in mm) the snap connector rests above the board. 3mm is standard. 0mm results in a flush fit. 
+//Height (in mm) the snap connector rests above the board. 3mm is standard. 0mm results in a flush fit.
 Snap_Connector_Height = 3;
-//Scale of the Snap Connector holding 'bumpouts'. 1 is standard. 0.5 is half size. 1.5 is 50% larger. Large = stronger hold. 
+//Scale of the Snap Connector holding 'bumpouts'. 1 is standard. 0.5 is half size. 1.5 is 50% larger. Large = stronger hold.
 Snap_Holding_Tolerance = 1; //[0.5:0.05:2.0]
 //Length of the treaded portion of the snap connector. 3.6mm is standard.
 Snap_Thread_Height = 3.6;
 
 /*[Options: Bolts]*/
-//length of the threaded portion of small screw. MB is 6mm thick and the recessed hole in base channels is 1mm deep. 
+//length of the threaded portion of small screw. MB is 6mm thick and the recessed hole in base channels is 1mm deep.
 Thread_Length_Sm = 6.5;
 
 /*[Advanced Options]*/
@@ -56,7 +57,7 @@ Pitch_Lg = 2.5;
 //Diameter (in mm) at the outer threads
 Outer_Diameter_Lg = 22.245;
 //Angle of the one side of the thread
-Flank_Angle_Lg = 45;  
+Flank_Angle_Lg = 45;
 //Depth (in mm) of the thread
 Thread_Depth_Lg = 0.75;
 //Diameter of the hole down the middle of the bolt
@@ -151,7 +152,7 @@ BEGIN SNAP CONNECTOR
 */
 
 module snapConnectBacker(offset = 0, holdingTolerance=1, anchor=CENTER, spin=0, orient=UP){
-    attachable(anchor, spin, orient, size=[11.4465*2, 11.4465*2, 6.17+offset]){ 
+    attachable(anchor, spin, orient, size=[11.4465*2, 11.4465*2, 6.17+offset]){
     //bumpout profile
     bumpout = turtle([
         "ymove", -2.237,
@@ -172,14 +173,14 @@ module snapConnectBacker(offset = 0, holdingTolerance=1, anchor=CENTER, spin=0, 
                     attach(TOP, BOT, shiftout=-0.01) oct_prism(h = offset, r = 12.9885, anchor=BOTTOM);
                         //top bevel - not used when applied as backer
                         //position(TOP) oct_prism(h = 0.4, r1 = 12.9985, r2 = 12.555, anchor=BOTTOM);
-            
+
             //end base
             //bumpouts
             attach([RIGHT, LEFT, FWD, BACK],LEFT, shiftout=-0.01)  color("green") down(0.87) fwd(1)scale([1,1,holdingTolerance]) zrot(90)offset_sweep(path = bumpout, height=3);
             //delete tools
             //Bottom and side cutout - 2 cubes that form an L (cut from bottom and from outside) and then rotated around the side
-            tag("remove") 
-                 align(BOTTOM, [RIGHT, BACK, LEFT, FWD], inside=true, shiftout=0.01, inset = 1.6) 
+            tag("remove")
+                 align(BOTTOM, [RIGHT, BACK, LEFT, FWD], inside=true, shiftout=0.01, inset = 1.6)
                     color("lightblue") cuboid([0.8,7.161,3.4], spin=90*$idx)
                         align(RIGHT, [TOP]) cuboid([0.8,7.161,1], anchor=BACK);
             }
@@ -189,7 +190,7 @@ module snapConnectBacker(offset = 0, holdingTolerance=1, anchor=CENTER, spin=0, 
 
     //octo_prism - module that creates an oct_prism with anchors positioned on the faces instead of the edges (as per cyl default for 8 sides)
     module oct_prism(h, r=0, r1=0, r2=0, anchor=CENTER, spin=0, orient=UP) {
-        attachable(anchor, spin, orient, size=[max(r*2, r1*2, r2*2), max(r*2, r1*2, r2*2), h]){ 
+        attachable(anchor, spin, orient, size=[max(r*2, r1*2, r2*2), max(r*2, r1*2, r2*2), h]){
             down(h/2)
             if (r != 0) {
                 // If r is provided, create a regular octagonal prism with radius r
@@ -199,9 +200,9 @@ module snapConnectBacker(offset = 0, holdingTolerance=1, anchor=CENTER, spin=0, 
                 rotate (22.5) cylinder(h=h, r1=r1, r2=r2, $fn=8) rotate (-22.5);
             } else {
                 echo("Error: You must provide either r or both r1 and r2.");
-            }  
-            children(); 
+            }
+            children();
         }
     }
-    
+
 }

--- a/Underware/Underware_Diagonal_Channel.scad
+++ b/Underware/Underware_Diagonal_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -16,6 +16,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -38,7 +39,7 @@ Straight_Distance = 25;//[12.5:12.5:100]
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -59,15 +60,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -91,10 +87,10 @@ Base_Screw_Hole_Inner_Depth = 1;
 Base_Screw_Hole_Cone = false;
 
 if(Base_Top_or_Both != "Top")
-    color_this(Global_Color) 
+    color_this(Global_Color)
         diagonalChannelBase(unitsOver = Units_Over, unitsUp = Units_Up, outputDirection = Output_Direction, straightDistance = Straight_Distance, widthMM = Channel_Width_in_Units * Grid_Size, anchor = BOT);
 if(Base_Top_or_Both != "Base")
-    color_this(Global_Color) left(channelWidth*sign(Units_Over)+partSeparation*sign(Units_Over)) 
+    color_this(Global_Color) left(channelWidth*sign(Units_Over)+partSeparation*sign(Units_Over))
         diagonalChannelTop(unitsOver = Units_Over, unitsUp = Units_Up, outputDirection = Output_Direction, straightDistance = Straight_Distance, widthMM = Channel_Width_in_Units * Grid_Size, heightMM = Channel_Internal_Height, anchor = TOP, orient = Show_Attached ? TOP :  BOT);
 
 /*
@@ -108,7 +104,7 @@ module diagonalChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward"
     attachable(anchor, spin, orient, size=[50,50, baseHeight]){
         down(baseHeight/2)
             diff("holes"){
-                path_sweep2d(baseProfile(widthMM = widthMM), 
+                path_sweep2d(baseProfile(widthMM = widthMM),
                     path= outputDirection == "Forward" ? [
                         [0,0], //start
                         [0,Straight_Distance*sign(unitsUp)+0.1], //distance forward or back. 0.05 is a subtle cheat that allows for a perfect side shift without a bad polygon
@@ -122,7 +118,7 @@ module diagonalChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward"
                         [unitsOver*Grid_Size+Grid_Size/2*sign(unitsOver),unitsUp*Grid_Size+Grid_Size/2*sign(unitsUp)] //last position either out the angle or straight out
                     ]
                     ) {
-                    tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(Grid_Size/2*sign(unitsUp)) down(0.01) 
+                    tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(Grid_Size/2*sign(unitsUp)) down(0.01)
                         if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -131,8 +127,8 @@ module diagonalChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward"
                         else if(Mounting_Method == "Flat") ; //do nothing
                         else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
                     //outside holes forward option
-                    tag("holes") 
-                        if(outputDirection == "Forward") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(unitsUp*Grid_Size+Grid_Size*sign(unitsUp)-Grid_Size/2*sign(unitsUp)) right(unitsOver*Grid_Size)down(0.01) 
+                    tag("holes")
+                        if(outputDirection == "Forward") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(unitsUp*Grid_Size+Grid_Size*sign(unitsUp)-Grid_Size/2*sign(unitsUp)) right(unitsOver*Grid_Size)down(0.01)
                         if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -141,8 +137,8 @@ module diagonalChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward"
                         else if(Mounting_Method == "Flat") ; //do nothing
                         else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
                     //outside holes turn option
-                    tag("holes") 
-                        if(outputDirection == "Turn") ycopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(unitsUp*Grid_Size+Grid_Size/2*sign(unitsUp)) right(unitsOver*Grid_Size)down(0.01) 
+                    tag("holes")
+                        if(outputDirection == "Turn") ycopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(unitsUp*Grid_Size+Grid_Size/2*sign(unitsUp)) right(unitsOver*Grid_Size)down(0.01)
                         if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                         else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                         else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -160,7 +156,7 @@ module diagonalChannelTop(unitsOver = 1, unitsUp=3, outputDirection = "Forward",
     attachable(anchor, spin, orient, size=[50,50, topHeight + (heightMM-12)]){ //Curve_Radius_in_Units*channelWidth/2
         down(topHeight/2 + (heightMM - 12)/2)
             diff("holes"){
-                path_sweep2d(topProfile(widthMM = widthMM, heightMM = heightMM), 
+                path_sweep2d(topProfile(widthMM = widthMM, heightMM = heightMM),
                     path= outputDirection == "Forward" ? [
                         [0,0], //start
                         [0,Straight_Distance*sign(unitsUp)+0.1], //distance forward or back. 0.05 is a subtle cheat that allows for a perfect side shift without a bad polygon
@@ -178,109 +174,3 @@ module diagonalChannelTop(unitsOver = 1, unitsUp=3, outputDirection = "Forward",
         children();
     }
 }
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_I_Channel.scad
+++ b/Underware/Underware_I_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -17,6 +17,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -25,7 +26,7 @@ Base_Top_or_Both = "Both"; // [Base, Top, Both]
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -43,7 +44,7 @@ Channel_Width_in_Units = 1;
 //height inside the channel (in mm)
 Channel_Internal_Height = 12; //[12:6:72]
 //length of channel in units (default unit is 25mm)
-Channel_Length_Units = 5; 
+Channel_Length_Units = 5;
 
 /*[Cord Cutouts]*/
 Number_of_Cord_Cutouts = 0;
@@ -63,7 +64,7 @@ Text = "Hands on Katie";  // Text to be displayed
 Text_x_coordinate = 0;  // Adjusting the x position of the text
 //Font must be installed on local machine if using local OpenSCAD
 Font = "Raleway"; // [Asap, Bangers, Changa One, Chewy, Harmony OS Sans,Inter,Inter Tight,Lora,Merriweather Sans,Montserrat,Noto Emoji,Noto Sans,Noto Sans Adlam,Noto Sans Adlam Unjoined,Noto Sans Arabic,Noto Sans Arabic UI,Noto Sans Armenian,Noto Sans Balinese,Noto Sans Bamum,Noto Sans Bassa Vah,Noto Sans Bengali,Noto Sans Bengali UI,Noto Sans Canadian Aboriginal,Noto Sans Cham,Noto Sans Cherokee,Noto Sans Devanagari,Noto Sans Display,Noto Sans Ethiopic,Noto Sans Georgian,Noto Sans Gujarati,Noto Sans Gunjala Gondi,Noto Sans Gurmukhi,Noto Sans Gurmukhi UI,Noto Sans HK,Noto Sans Hanifi Rohingya,Noto Sans Hebrew,Noto Sans JP,Noto Sans Javanese,Noto Sans KR,Noto Sans Kannada,Noto Sans Kannada UI,Noto Sans Kawi,Noto Sans Kayah Li,Noto Sans Khmer,Noto Sans Khmer UI,Noto Sans Lao,Noto Sans Lao Looped,Noto Sans Lao UI,Noto Sans Lisu,Noto Sans Malayalam,Noto Sans Malayalam UI,Noto Sans Medefaidrin,Noto Sans Meetei Mayek,Noto Sans Mono,Noto Sans Myanmar,Noto Sans NKo Unjoined,Noto Sans Nag Mundari,Noto Sans New Tai Lue,Noto Sans Ol Chiki,Noto Sans Oriya,Noto Sans SC,Noto Sans Sinhala,Noto Sans Sinhala UI,Noto Sans Sora Sompeng,Noto Sans Sundanese,Noto Sans Symbols,Noto Sans Syriac,Noto Sans Syriac Eastern,Noto Sans TC,Noto Sans Tai Tham,Noto Sans Tamil,Noto Sans Tamil UI,Noto Sans Tangsa,Noto Sans Telugu,Noto Sans Telugu UI,Noto Sans Thaana,Noto Sans Thai,Noto Sans Thai UI,Noto Sans Vithkuqi,Nunito,Nunito Sans,Open Sans,Open Sans Condensed,Oswald,Playfair Display,Plus Jakarta Sans,Raleway,Roboto,Roboto Condensed,Roboto Flex,Roboto Mono,Roboto Serif,Roboto Slab,Rubik,Source Sans 3,Ubuntu Sans,Ubuntu Sans Mono,Work Sans]
-//Styling of selecte font. Note that not all fonts support all styles. 
+//Styling of selecte font. Note that not all fonts support all styles.
 Font_Style = "Regular"; // [Regular,Bold,Medium,SemiBold,Light,ExtraBold,Black,ExtraLight,Thin,Bold Italic,Italic,Light Italic,Medium Italic]
 Text_size = 10;    // Font size
 //Color of label text (color names found at https://en.wikipedia.org/wiki/Web_colors)
@@ -78,15 +79,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -137,8 +133,17 @@ module straightChannelBase(lengthMM, widthMM, anchor, spin, orient){
         fwd(lengthMM/2) down(maxY(baseProfileHalf)/2)
         diff("holes")
         zrot(90) path_sweep(baseProfile(widthMM = widthMM), turtle(["xmove", lengthMM]))
-        tag("holes")  right(lengthMM/2) grid_copies(spacing=Grid_Size, inside=rect([lengthMM-1,widthMM-1])) 
-            if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3.5-Base_Screw_Hole_Inner_Depth+0.02, d1=Base_Screw_Hole_Cone ? Base_Screw_Hole_Inner_Diameter : Base_Screw_Hole_Outer_Diameter, d2=Base_Screw_Hole_Outer_Diameter, $fn=25);
+        tag("holes")  right(lengthMM/2) grid_copies(spacing=Grid_Size, inside=rect([lengthMM-1,widthMM-1]))
+            if(Mounting_Method == "Direct Multiboard Screw")
+              up(Base_Screw_Hole_Inner_Depth)
+              cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP)
+              attach(TOP, BOT, overlap=0.01)
+              cyl(
+                h=3.5-Base_Screw_Hole_Inner_Depth+0.02,
+                d1=Base_Screw_Hole_Cone ? Base_Screw_Hole_Inner_Diameter : Base_Screw_Hole_Outer_Diameter,
+                d2=Base_Screw_Hole_Outer_Diameter,
+                $fn=25
+              );
             else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
             else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
                 //wood screw head
@@ -155,119 +160,13 @@ module straightChannelTop(lengthMM, widthMM, heightMM = 12, anchor, spin, orient
         diff("Cable_Cutouts")
         zrot(90) path_sweep(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", lengthMM]))
             tag("Cable_Cutouts") down(5+0.01) up(10.968/2 + (heightMM - 12)/2) right(lengthMM/2)
-                xcopies(n=Number_of_Cord_Cutouts, spacing= Distance_Between_Cutouts) 
+                xcopies(n=Number_of_Cord_Cutouts, spacing= Distance_Between_Cutouts)
                     up(2.49)
                     fwd(Cord_Side_Cutouts == "Left Side" ? channelWidth/2 :
-                        Cord_Side_Cutouts == "Right Side" ? -channelWidth/2 : 
+                        Cord_Side_Cutouts == "Right Side" ? -channelWidth/2 :
                         0)
                     left(-Shift_Cutouts_Forward_or_Back)
                         cuboid([Cord_Cutout_Width, Cord_Side_Cutouts == "Both Sides" ? channelWidth + 5 : channelWidth/2, Channel_Internal_Height-2], chamfer = 2, edges=[TOP+LEFT, TOP+RIGHT]);
     children();
     }
 }
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_L_Channel.scad
+++ b/Underware/Underware_L_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -16,6 +16,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -32,7 +33,7 @@ L_Channel_Length_in_Units = 1;
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -52,15 +53,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -107,8 +103,8 @@ module lChannelBase(lengthMM = 50, widthMM = 25, anchor, spin, orient){
         left(widthMM/2+lengthMM/2) fwd(lengthMM/2)
         down(baseHeight/2)
         diff("holes"){
-            path_sweep2d(baseProfile(widthMM = widthMM), turtle(["move", calculatedPath, "turn", 90, "move",calculatedPath] )); 
-            tag("holes") right(widthMM/2+lengthMM/2) back(lengthMM/2) grid_copies(spacing=Grid_Size, inside=rect([widthMM+lengthMM-1,widthMM+lengthMM-1])) 
+            path_sweep2d(baseProfile(widthMM = widthMM), turtle(["move", calculatedPath, "turn", 90, "move",calculatedPath] ));
+            tag("holes") right(widthMM/2+lengthMM/2) back(lengthMM/2) grid_copies(spacing=Grid_Size, inside=rect([widthMM+lengthMM-1,widthMM+lengthMM-1]))
                 if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=10, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                 else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                 else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -123,115 +119,9 @@ module lChannelBase(lengthMM = 50, widthMM = 25, anchor, spin, orient){
 module lChannelTop(lengthMM = 50, widthMM = 25, heightMM = 12, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[widthMM+lengthMM, widthMM+lengthMM, topHeight + (heightMM-12)]){
         let(calculatedPath = widthMM/2+lengthMM)
-        left(widthMM/2+lengthMM/2) fwd(lengthMM/2) 
+        left(widthMM/2+lengthMM/2) fwd(lengthMM/2)
         down(topHeight/2 + (heightMM - 12)/2)
-        path_sweep2d(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["move", calculatedPath, "turn", 90, "move",calculatedPath] )); 
+        path_sweep2d(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["move", calculatedPath, "turn", 90, "move",calculatedPath] ));
     children();
     }
 }
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_Mitre_Channel.scad
+++ b/Underware/Underware_Mitre_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -16,6 +16,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Channel Size]*/
 //width of channel in units (default unit is 25mm)
@@ -34,13 +35,9 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
+
 //length of channel in units (default unit is 25mm)
-Channel_Length_Units = 6; 
+Channel_Length_Units = 6;
 
 /*
 
@@ -48,119 +45,12 @@ Channel_Length_Units = 6;
 
 */
 
-color_this(Global_Color) 
+color_this(Global_Color)
     left(3)
     half_of(UP+LEFT, s=Channel_Length_Units*Grid_Size*2+10)
         path_sweep(topProfile(widthMM = channelWidth, heightMM = Channel_Internal_Height), turtle(["xmove", Length_of_Longest_Edge_1*2-50+14.032*2- (Channel_Internal_Height-12)*2]), anchor=TOP, orient=BOT);
 
-    color_this(Global_Color) 
+    color_this(Global_Color)
         down(3)yrot(-90) xrot(180)
             half_of(UP+LEFT, s=Channel_Length_Units*Grid_Size*2+10)
             path_sweep(topProfile(widthMM = channelWidth, heightMM = Channel_Internal_Height), turtle(["xmove", Length_of_Longest_Edge_2+14.032*2+14 - (Channel_Internal_Height-12)*2]), anchor=TOP, orient=BOT);
-
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_Shared.scad
+++ b/Underware/Underware_Shared.scad
@@ -1,0 +1,113 @@
+//BEGIN PROFILES - Must match across all files
+
+include <BOSL2/std.scad>
+include <BOSL2/rounding.scad>
+include <BOSL2/threading.scad>
+
+topHeight = 10.968;
+baseHeight = 9.63;
+interlockOverlap = 3.09; //distance that the top and base overlap each other
+interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
+partSeparation = 10;
+
+//take the two halves of base and merge them
+function baseProfile(widthMM = 25) =
+    union(
+        left((widthMM-25)/2,baseProfileHalf),
+        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
+        back(3.5/2,rect([widthMM-25+0.02,3.5]))
+    );
+
+//take the two halves of base and merge them
+function topProfile(widthMM = 25, heightMM = 12) =
+    union(
+        left((widthMM-25)/2,topProfileHalf(heightMM)),
+        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
+        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2]))
+    );
+
+function baseDeleteProfile(widthMM = 25) =
+    union(
+        left((widthMM-25)/2,baseDeleteProfileHalf),
+        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
+        back(6.575,rect([widthMM-25+0.02,6.15]))
+    );
+
+function topDeleteProfile(widthMM, heightMM = 12) =
+    union(
+        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)),
+        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
+        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12]))
+    );
+
+baseProfileHalf =
+    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
+        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions.
+        [
+            [0,-4.447],
+            [-8.5,-4.447],
+            [-9.5,-3.447],
+            [-9.5,1.683],
+            [-10.517,1.683],
+            [-11.459,1.422],
+            [-11.459,-0.297],
+            [-11.166,-0.592],
+            [-11.166,-1.414],
+            [-11.666,-1.914],
+            [-12.517,-1.914],
+            [-12.517,-4.448],
+            [-10.517,-6.448],
+            [-10.517,-7.947],
+            [0,-7.947]
+        ]
+);
+
+function topProfileHalf(heightMM = 12) =
+        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions.
+        [
+            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
+            [0,9.554 + (heightMM - 12)],
+            [-8.517,9.554 + (heightMM - 12)],
+            [-12.517,5.554 + (heightMM - 12)],
+            [-12.517,-1.414],
+            [-11.166,-1.414],
+            [-11.166,-0.592],
+            [-11.459,-0.297],
+            [-11.459,1.422],
+            [-10.517,1.683],
+            [-10.517,4.725 + (heightMM - 12)],
+            [-7.688,7.554 + (heightMM - 12)]
+        ]
+        );
+
+baseDeleteProfileHalf =
+    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
+        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions.
+        [
+            [0,-4.447], //inner x axis point with width adjustment
+            [0,1.683+0.02],
+            [-9.5,1.683+0.02],
+            [-9.5,-3.447],
+            [-8.5,-4.447],
+        ]
+);
+
+function topDeleteProfileHalf(heightMM = 12)=
+        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions.
+        [
+            [0,7.554 + (heightMM - 12)],
+            [-7.688,7.554 + (heightMM - 12)],
+            [-10.517,4.725 + (heightMM - 12)],
+            [-10.517,1.683],
+            [-11.459,1.422],
+            [-11.459,-0.297],
+            [-11.166,-0.592],
+            [-11.166,-1.414-0.02],
+            [0,-1.414-0.02]
+        ]
+        );
+
+
+//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
+function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
+function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));

--- a/Underware/Underware_T_Channel.scad
+++ b/Underware/Underware_T_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -16,6 +16,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -30,7 +31,7 @@ Channel_Internal_Height = 12; //[12:6:72]
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -50,15 +51,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -94,7 +90,7 @@ color_this(Global_Color)
 if(Base_Top_or_Both != "Base")
 color_this(Global_Color)
     right(Show_Attached ? 0 : partSeparation)
-    up(Show_Attached ? interlockFromFloor : 0) 
+    up(Show_Attached ? interlockFromFloor : 0)
         tIntersectionTop(widthMM = channelWidth, heightMM = Channel_Internal_Height, anchor=Show_Attached ? BOT : TOP+RIGHT, orient= Show_Attached ? TOP : BOT);
 
 /*
@@ -106,7 +102,7 @@ color_this(Global_Color)
 //T CHANNELS
 module tIntersectionBase(widthMM, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[channelWidth+Grid_Size, channelWidth+Grid_Size*2, baseHeight]){
-        down(baseHeight/2) 
+        down(baseHeight/2)
         left(Grid_Size/2)
         union(){
         diff("channelClear holes")
@@ -116,7 +112,7 @@ module tIntersectionBase(widthMM, anchor, spin, orient){
         //long channel
         zrot(90) left(channelWidth/2+Grid_Size)path_sweep(baseProfile(widthMM = widthMM), turtle(["move", channelWidth+Grid_Size*2]));
         tag("channelClear") straightChannelBaseDeleteTool(widthMM = channelWidth+0.02, lengthMM = channelWidth+Grid_Size*2, anchor=BOT);
-        tag("holes") grid_copies(n=2+Channel_Width_in_Units, spacing=Grid_Size) 
+        tag("holes") grid_copies(n=2+Channel_Width_in_Units, spacing=Grid_Size)
             if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
             else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
             else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -150,7 +146,7 @@ module tIntersectionTop(widthMM, heightMM, anchor, spin, orient){
 module straightChannelBaseDeleteTool(lengthMM, widthMM, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[widthMM, lengthMM, baseHeight]){
         fwd(lengthMM/2) down(maxY(baseProfileHalf)/2)
-        zrot(90) path_sweep(baseDeleteProfile(widthMM = widthMM), turtle(["xmove", lengthMM])); 
+        zrot(90) path_sweep(baseDeleteProfile(widthMM = widthMM), turtle(["xmove", lengthMM]));
     children();
     }
 }
@@ -158,114 +154,7 @@ module straightChannelBaseDeleteTool(lengthMM, widthMM, anchor, spin, orient){
 module straightChannelTopDeleteTool(lengthMM, widthMM, heightMM = 12, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[widthMM, lengthMM, topHeight + (heightMM-12)]){
         fwd(lengthMM/2) down(topHeight/2 + (heightMM - 12)/2)
-        zrot(90) path_sweep(topDeleteProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", lengthMM])); 
-    children(); 
+        zrot(90) path_sweep(topDeleteProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", lengthMM]));
+    children();
     }
 }
-
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_X_Channel.scad
+++ b/Underware/Underware_X_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -16,6 +16,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -30,7 +31,7 @@ Channel_Internal_Height = 12; //[12:6:72]
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -50,15 +51,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -92,13 +88,13 @@ x_channel_Y = channelWidth+Grid_Size*2;
 */
 
 if(Base_Top_or_Both != "Top")
-color_this(Global_Color) 
+color_this(Global_Color)
     left(Show_Attached ? 0 : x_channel_X / 2 + partSeparation/2)
         XChannelBase(widthMM = channelWidth, anchor=BOT);
 if(Base_Top_or_Both != "Base")
 color_this(Global_Color)
     right(Show_Attached ? 0 : x_channel_X / 2 + partSeparation/2)
-    up(Show_Attached ? interlockFromFloor : 0) 
+    up(Show_Attached ? interlockFromFloor : 0)
         XChannelTop(widthMM = channelWidth, heightMM = Channel_Internal_Height, anchor=Show_Attached ? BOT : TOP, orient= Show_Attached ? TOP : BOT);
 
 /*
@@ -113,8 +109,8 @@ module XChannelBase(widthMM, anchor, spin, orient){
         down(baseHeight/2)left((channelWidth/2+Grid_Size)) path_sweep(baseProfile(widthMM = widthMM), turtle(["xmove", channelWidth+Grid_Size*2]));
         down(baseHeight/2)fwd(channelWidth/2+Grid_Size) zrot(90)path_sweep(baseProfile(widthMM = widthMM), turtle(["xmove", channelWidth+Grid_Size*2]));
         //zrot_copies(n=4) straightChannelBase(lengthMM = Grid_Size*3, widthMM = channelWidth) //old approach with unwanted straight channel inheritance
-        tag("channelClear") zrot_copies(n=4) straightChannelBaseDeleteTool(widthMM = channelWidth+0.02, lengthMM = Grid_Size+channelWidth); 
-        tag("holes") down(5)grid_copies(spacing=Grid_Size, inside=rect([x_channel_X-1,x_channel_Y-1])) 
+        tag("channelClear") zrot_copies(n=4) straightChannelBaseDeleteTool(widthMM = channelWidth+0.02, lengthMM = Grid_Size+channelWidth);
+        tag("holes") down(5)grid_copies(spacing=Grid_Size, inside=rect([x_channel_X-1,x_channel_Y-1]))
             if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
             else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
             else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -133,7 +129,7 @@ module XChannelTop(widthMM, heightMM = 12, anchor, spin, orient){
     diff("channelClear"){
         left((channelWidth/2+Grid_Size)) path_sweep(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", channelWidth+Grid_Size*2]));
         fwd(channelWidth/2+Grid_Size) zrot(90) path_sweep(topProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", channelWidth+Grid_Size*2]));
-        tag("channelClear") zrot_copies(n=4) straightChannelTopDeleteTool(widthMM = channelWidth+0.02, lengthMM = Grid_Size+channelWidth, heightMM = heightMM, anchor=BOT); 
+        tag("channelClear") zrot_copies(n=4) straightChannelTopDeleteTool(widthMM = channelWidth+0.02, lengthMM = Grid_Size+channelWidth, heightMM = heightMM, anchor=BOT);
     }
     children();
     }
@@ -142,7 +138,7 @@ module XChannelTop(widthMM, heightMM = 12, anchor, spin, orient){
 module straightChannelBaseDeleteTool(lengthMM, widthMM, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[widthMM, lengthMM, baseHeight]){
         fwd(lengthMM/2) down(maxY(baseProfileHalf)/2)
-        zrot(90) path_sweep(baseDeleteProfile(widthMM = widthMM), turtle(["xmove", lengthMM])); 
+        zrot(90) path_sweep(baseDeleteProfile(widthMM = widthMM), turtle(["xmove", lengthMM]));
     children();
     }
 }
@@ -150,113 +146,7 @@ module straightChannelBaseDeleteTool(lengthMM, widthMM, anchor, spin, orient){
 module straightChannelTopDeleteTool(lengthMM, widthMM, heightMM = 12, anchor, spin, orient){
     attachable(anchor, spin, orient, size=[widthMM, lengthMM, topHeight + (heightMM-12)]){
         fwd(lengthMM/2) down(topHeight/2 + (heightMM - 12)/2)
-        zrot(90) path_sweep(topDeleteProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", lengthMM])); 
-    children(); 
+        zrot(90) path_sweep(topDeleteProfile(widthMM = widthMM, heightMM = heightMM), turtle(["xmove", lengthMM]));
+    children();
     }
 }
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-

--- a/Underware/Underware_Y_Channel.scad
+++ b/Underware/Underware_Y_Channel.scad
@@ -3,7 +3,7 @@ This code and all parts derived from it are Licensed Creative Commons 4.0 Attrib
 
 Documentation available at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 
-Credit to 
+Credit to
     First and foremost - Katie and her community at Hands on Katie on Youtube, Patreon, and Discord
     @David D on Printables for Multiconnect
     Jonathan at Keep Making for Multiboard
@@ -16,6 +16,7 @@ Credit to
 include <BOSL2/std.scad>
 include <BOSL2/rounding.scad>
 include <BOSL2/threading.scad>
+include <Underware_Shared.scad>
 
 /*[Choose Part]*/
 Base_Top_or_Both = "Both"; // [Base, Top, Both]
@@ -31,14 +32,14 @@ Y_Units_Over = 1; //[1:1:10]
 Y_Units_Up = 1;//[1:1:10]
 //Output the same direction (Forward) or at 90 degrees in direction of shift (Turn).
 Y_Output_Direction = "Forward"; //[Forward, Turn]
-//Distance that the parts are straight in on the ends (before the angle). Unexpected behavior on wider channels may be resolved by changing this slider. 
+//Distance that the parts are straight in on the ends (before the angle). Unexpected behavior on wider channels may be resolved by changing this slider.
 Y_Straight_Distance = 12.5; //[12.5:12.5:100]
 
 /*[Mounting Options]*/
 //How do you intend to mount the channels to a surface such as Honeycomb Storage Wall or Multiboard? See options at https://handsonkatie.com/underware-2-0-the-made-to-measure-collection/
 Mounting_Method = "Threaded Snap Connector"; //[Threaded Snap Connector, Direct Multiboard Screw, Magnet, Wood Screw, Flat]
 //Diameter of the magnet (in mm)
-Magnet_Diameter = 4.0; 
+Magnet_Diameter = 4.0;
 //Thickness of the magnet (in mm)
 Magnet_Thickness = 1.5;
 //Add a tolerance to the magnet hole to make it easier to insert the magnet.
@@ -58,15 +59,10 @@ Global_Color = "SlateBlue";
 
 /*[Hidden]*/
 channelWidth = Channel_Width_in_Units * Grid_Size;
-baseHeight = 9.63;
-topHeight = 10.968;
-interlockOverlap = 3.09; //distance that the top and base overlap each other
-interlockFromFloor = 6.533; //distance from the bottom of the base to the bottom of the top when interlocked
-partSeparation = 10;
 
 ///*[Visual Options]*/
 Debug_Show_Grid = false;
-//View the parts as they attach. Note that you must disable this before exporting for printing. 
+//View the parts as they attach. Note that you must disable this before exporting for printing.
 Show_Attached = false;
 
 ///*[Small Screw Profile]*/
@@ -117,10 +113,10 @@ module yChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward", strai
         fwd(unitsUp*Grid_Size/2+straightDistance)
         down(baseHeight/2)
             diff("holes"){
-                xflip_copy() 
+                xflip_copy()
                 {
-                    right_half(s=max(unitsUp*Grid_Size*4,unitsOver*Grid_Size*4)) {//s should be a number larger than twice the size of the object's largest axis. Thew some random numbers in here for now. If mirror issues surface, this is likely the culprit. 
-                        path_sweep2d(baseProfile(widthMM = widthMM), 
+                    right_half(s=max(unitsUp*Grid_Size*4,unitsOver*Grid_Size*4)) {//s should be a number larger than twice the size of the object's largest axis. Thew some random numbers in here for now. If mirror issues surface, this is likely the culprit.
+                        path_sweep2d(baseProfile(widthMM = widthMM),
                             path= outputDirection == "Forward" ? [
                                 [0,0], //start
                                 [0,straightDistance*sign(unitsUp)+0.1], //distance forward or back. 0.05 is a subtle cheat that allows for a perfect side shift without a bad polygon
@@ -135,7 +131,7 @@ module yChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward", strai
                             ]
                             );
                     }}
-                            tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(Grid_Size/2*sign(unitsUp)) down(0.01) 
+                            tag("holes") xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) back(Grid_Size/2*sign(unitsUp)) down(0.01)
                                 if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                                 else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                                 else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -144,13 +140,13 @@ module yChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward", strai
                                 else if(Mounting_Method == "Flat") ; //do nothing
                                 else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
                             //outside holes forward option (right side)
-                            tag("holes") 
+                            tag("holes")
                                 if(outputDirection == "Forward")
                                     move_copies([
                                         [unitsOver*Grid_Size, unitsUp*Grid_Size+Grid_Size*sign(unitsUp)-Grid_Size/2*sign(unitsUp),-0.01],//right side
                                         [unitsOver*Grid_Size*-1, unitsUp*Grid_Size+Grid_Size*sign(unitsUp)-Grid_Size/2*sign(unitsUp),-0.01]
                                         ])
-                                        xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) //back(Units_Up*Grid_Size+Grid_Size*sign(unitsUp)-Grid_Size/2*sign(unitsUp)) //right(unitsOver*Grid_Size)down(0.01) 
+                                        xcopies(spacing = Grid_Size, n = Channel_Width_in_Units) //back(Units_Up*Grid_Size+Grid_Size*sign(unitsUp)-Grid_Size/2*sign(unitsUp)) //right(unitsOver*Grid_Size)down(0.01)
                                     if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                                     else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                                     else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
@@ -159,22 +155,22 @@ module yChannelBase(unitsOver = 1, unitsUp=3, outputDirection = "Forward", strai
                                     else if(Mounting_Method == "Flat") ; //do nothing
                                     else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
                             //outside holes turn option
-                            tag("holes") 
-                                if(outputDirection == "Turn") 
+                            tag("holes")
+                                if(outputDirection == "Turn")
                                     move_copies([
                                         [unitsOver*Grid_Size,unitsUp*Grid_Size+Grid_Size/2*sign(unitsUp),-0.01],
                                         [-unitsOver*Grid_Size,unitsUp*Grid_Size+Grid_Size/2*sign(unitsUp),-0.01]
                                         ])
-                                        ycopies(spacing = Grid_Size, n = Channel_Width_in_Units)// back(Units_Up*Grid_Size+Grid_Size/2*sign(unitsUp)) //right(unitsOver*Grid_Size)down(0.01) 
+                                        ycopies(spacing = Grid_Size, n = Channel_Width_in_Units)// back(Units_Up*Grid_Size+Grid_Size/2*sign(unitsUp)) //right(unitsOver*Grid_Size)down(0.01)
                                 if(Mounting_Method == "Direct Multiboard Screw") up(Base_Screw_Hole_Inner_Depth) cyl(h=8, d=Base_Screw_Hole_Inner_Diameter, $fn=25, anchor=TOP) attach(TOP, BOT, overlap=0.01) cyl(h=3, d=Base_Screw_Hole_Outer_Diameter, $fn=25);
                                 else if(Mounting_Method == "Magnet") up(Magnet_Thickness+Magnet_Tolerance-0.01) cyl(h=Magnet_Thickness+Magnet_Tolerance, d=Magnet_Diameter+Magnet_Tolerance, $fn=50, anchor=TOP);
                                 else if(Mounting_Method == "Wood Screw") up(3.5 - Wood_Screw_Head_Height) cyl(h=3.5 - Wood_Screw_Head_Height+0.05, d=Wood_Screw_Thread_Diameter, $fn=25, anchor=TOP)
                                     //wood screw head
                                     attach(TOP, BOT, overlap=0.01) cyl(h=Wood_Screw_Head_Height+0.05, d1=Wood_Screw_Thread_Diameter, d2=Wood_Screw_Head_Diameter, $fn=25);
                                 else if(Mounting_Method == "Flat") ; //do nothing
-                                else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);  
+                                else up(6.5) trapezoidal_threaded_rod(d=Outer_Diameter_Sm, l=9, pitch=Pitch_Sm, flank_angle = Flank_Angle_Sm, thread_depth = Thread_Depth_Sm, $fn=50, bevel2 = true, blunt_start=false, anchor=TOP);
             if(Debug_Show_Grid)
-                #back(12.5) back(12.5*Channel_Width_in_Units-12.5) grid_copies(spacing=Grid_Size, inside=rect([200,200]))cyl(h=8, d=7, $fn=25);//temporary 
+                #back(12.5) back(12.5*Channel_Width_in_Units-12.5) grid_copies(spacing=Grid_Size, inside=rect([200,200]))cyl(h=8, d=7, $fn=25);//temporary
             }
         children();
     }
@@ -185,10 +181,10 @@ module yChannelTop(unitsOver = 1, unitsUp=3, heightMM = 12, outputDirection = "F
         fwd(unitsUp*Grid_Size/2+straightDistance)
         down((topHeight + (heightMM-12))/2)
             diff("holes"){
-                xflip_copy() 
+                xflip_copy()
                 {
-                    right_half(s=max(unitsUp*Grid_Size*4,unitsOver*Grid_Size*4)) {//s should be a number larger than twice the size of the object's largest axis. Thew some random numbers in here for now. If mirror issues surface, this is likely the culprit. 
-                        path_sweep2d(topProfile(widthMM = widthMM, heightMM = heightMM), 
+                    right_half(s=max(unitsUp*Grid_Size*4,unitsOver*Grid_Size*4)) {//s should be a number larger than twice the size of the object's largest axis. Thew some random numbers in here for now. If mirror issues surface, this is likely the culprit.
+                        path_sweep2d(topProfile(widthMM = widthMM, heightMM = heightMM),
                             path= outputDirection == "Forward" ? [
                                 [0,0], //start
                                 [0,straightDistance*sign(unitsUp)+0.1], //distance forward or back. 0.05 is a subtle cheat that allows for a perfect side shift without a bad polygon
@@ -207,111 +203,3 @@ module yChannelTop(unitsOver = 1, unitsUp=3, heightMM = 12, outputDirection = "F
         children();
     }
 }
-
-
-
-//BEGIN PROFILES - Must match across all files
-
-//take the two halves of base and merge them
-function baseProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseProfileHalf)), //fill middle if widening from standard 25mm
-        back(3.5/2,rect([widthMM-25+0.02,3.5]))
-    );
-
-//take the two halves of base and merge them
-function topProfile(widthMM = 25, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(topHeight-1 + heightMM-12 , rect([widthMM-25+0.02,2])) 
-    );
-
-function baseDeleteProfile(widthMM = 25) = 
-    union(
-        left((widthMM-25)/2,baseDeleteProfileHalf), 
-        right((widthMM-25)/2,mirror([1,0],baseDeleteProfileHalf)), //fill middle if widening from standard 25mm
-        back(6.575,rect([widthMM-25+0.02,6.15]))
-    );
-
-function topDeleteProfile(widthMM, heightMM = 12) = 
-    union(
-        left((widthMM-25)/2,topDeleteProfileHalf(heightMM)), 
-        right((widthMM-25)/2,mirror([1,0],topDeleteProfileHalf(heightMM))), //fill middle if widening from standard 25mm
-        back(4.474 + (heightMM-12)/2,rect([widthMM-25+0.02,8.988 + heightMM - 12])) 
-    );
-
-baseProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile and use fwd to place flush on the Y axis
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447],
-            [-8.5,-4.447],
-            [-9.5,-3.447],
-            [-9.5,1.683],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414],
-            [-11.666,-1.914],
-            [-12.517,-1.914],
-            [-12.517,-4.448],
-            [-10.517,-6.448],
-            [-10.517,-7.947],
-            [0,-7.947]
-        ]
-);
-
-function topProfileHalf(heightMM = 12) =
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],//-0.017 per Katie's diagram. Moved to zero
-            [0,9.554 + (heightMM - 12)],
-            [-8.517,9.554 + (heightMM - 12)],
-            [-12.517,5.554 + (heightMM - 12)],
-            [-12.517,-1.414],
-            [-11.166,-1.414],
-            [-11.166,-0.592],
-            [-11.459,-0.297],
-            [-11.459,1.422],
-            [-10.517,1.683],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)]
-        ]
-        );
-
-baseDeleteProfileHalf = 
-    fwd(-7.947, //take Katie's exact measurements for half the profile of the inside
-        //profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,-4.447], //inner x axis point with width adjustment
-            [0,1.683+0.02],
-            [-9.5,1.683+0.02],
-            [-9.5,-3.447],
-            [-8.5,-4.447],
-        ]
-);
-
-function topDeleteProfileHalf(heightMM = 12)=
-        back(1.414,//profile extracted from exact coordinates in Master Profile F360 sketch. Any additional modifications are added mathmatical functions. 
-        [
-            [0,7.554 + (heightMM - 12)],
-            [-7.688,7.554 + (heightMM - 12)],
-            [-10.517,4.725 + (heightMM - 12)],
-            [-10.517,1.683],
-            [-11.459,1.422],
-            [-11.459,-0.297],
-            [-11.166,-0.592],
-            [-11.166,-1.414-0.02],
-            [0,-1.414-0.02]
-        ]
-        );
-
-
-//calculate the max x and y points. Useful in calculating size of an object when the path are all positive variables originating from [0,0]
-function maxX(path) = max([for (p = path) p[0]]) + abs(min([for (p = path) p[0]]));
-function maxY(path) = max([for (p = path) p[1]]) + abs(min([for (p = path) p[1]]));
-
-


### PR DESCRIPTION
Extracted the shared profile definitions, and some of the constants that all were the same between files. The new file is Underware_Shared.scad, and I used `include` in each component to pull it in, which pulls in the variables and the function defs. 

I rendered each component after extracting the code to be sure I didn't break anything, but I'm not sure what a full test of things looks like. 

Also my editor apparently cares about trailing spaces so some of those changes came along too. 